### PR TITLE
allow passing arguments to urllib3 PoolManager

### DIFF
--- a/scripts/python/OpenSimRemoteControl.py
+++ b/scripts/python/OpenSimRemoteControl.py
@@ -98,7 +98,7 @@ class BulkUpdateItem() :
 class OpenSimRemoteControl() :
 
     # -----------------------------------------------------------------
-    def __init__(self, endpoint, async = False, logfile = None):
+    def __init__(self, endpoint, async = False, logfile = None, num_pools = 10, maxsize = 1):
         self.EndPoint = str(endpoint)
         self.AsyncRequest = async
         self.MessagesSent = 0
@@ -111,7 +111,7 @@ class OpenSimRemoteControl() :
         self.Scene = ''
         self.DomainList = ['Dispatcher', 'RemoteControl', 'RemoteSensor']
         
-        self.PoolManager = urllib3.PoolManager()
+        self.PoolManager = urllib3.PoolManager(num_pools=num_pools, maxsize=maxsize)
 
     # -----------------------------------------------------------------
     def _PostDebug(self, oparms):


### PR DESCRIPTION
When using OpenSimRemoteControl I keep getting connection pool is full, discarding connection. The largest issue was the maxsize value, which determines the number of connections the PoolManager can keep open. The default value is 1. My application writes to OpenSim several times, which eventually led to closing/reopening connections constantly. By changing num_pools to 100 and maxsize to 10, that problem disappeared and the application worked well.

This patch simply allows num_pools and maxsize to be set when creating OpenSimRemoteControl. An alternative would be passing a settings variable, which I can also do if you prefer.
